### PR TITLE
Alterada configuração para dar acesso ao módulo de importação de eventos pelo selo

### DIFF
--- a/compose/common/config.d/module.eventimporter.php
+++ b/compose/common/config.d/module.eventimporter.php
@@ -7,6 +7,10 @@ $app = App::i();
 return [
     'module.EventImporter' => [
         'enabled' => function () use ($app) {
+            if($app->user->is("admin")) {
+                return true;
+            }
+
             $agentSealRelations = $app->repo('AgentSealRelation')->findBy(['seal' => 12]);
             $agents = array_map(function($sealRelation) {
                 return $sealRelation->owner;

--- a/compose/common/config.d/module.eventimporter.php
+++ b/compose/common/config.d/module.eventimporter.php
@@ -7,16 +7,17 @@ $app = App::i();
 return [
     'module.EventImporter' => [
         'enabled' => function () use ($app) {
-            //Agentes especificos
-            $agentsPermissions = [29694, 5352, 34866, 28932, 6139,35355,40999,65009,100799,21927,9327,
-                111866,114694,117511,25535,117458,54351,117447,101124,99846,105602,26250,109559,19133,
-                40263,110774,119983,40179,114885,14915,36368,18630,18468,26900,36280,5960,43779,95659,
-                33624,18940];
-            //se for admin+ do mapa
-            $admin = $app->user->is("admin");    
-            if (in_array($app->getUser()->profile->id, $agentsPermissions) || $admin) {
-                return true;
+            $agentSealRelations = $app->repo('AgentSealRelation')->findBy(['seal' => 12]);
+            $agents = array_map(function($sealRelation) {
+                return $sealRelation->owner;
+            }, $agentSealRelations);
+
+            for($i = 0; $i < count($agents); $i++) {
+                if($agents[$i]->canUser('@control'))
+                    return true;
             }
+
+            return false;
         }
     ]
 ];

--- a/compose/local/config.d/module.eventimporter.php
+++ b/compose/local/config.d/module.eventimporter.php
@@ -7,13 +7,17 @@ $app = App::i();
 return [
     'module.EventImporter' => [
         'enabled' => function () use ($app) {
-            $agentsPermissions = [29694, 5352, 34866, 28932, 6139,35355,40999,65009,100799,21927,9327,
-                111866,114694,117511,25535,117458,54351,117447,101124,99846,105602,26250,109559,19133,
-                40263,110774,119983,40179,114885,14915,36368,18630,18468,26900,36280,5960,43779,95659,
-                33624,18940];
-            if (in_array($app->getUser()->profile->id, $agentsPermissions)) {
-                return true;
+            $agentSealRelations = $app->repo('AgentSealRelation')->findBy(['seal' => 12]);
+            $agents = array_map(function($sealRelation) {
+                return $sealRelation->owner;
+            }, $agentSealRelations);
+
+            for($i = 0; $i < count($agents); $i++) {
+                if($agents[$i]->canUser('@control'))
+                    return true;
             }
+
+            return false;
         }
     ]
 ];

--- a/compose/local/config.d/module.eventimporter.php
+++ b/compose/local/config.d/module.eventimporter.php
@@ -7,6 +7,10 @@ $app = App::i();
 return [
     'module.EventImporter' => [
         'enabled' => function () use ($app) {
+            if($app->user->is("admin")) {
+                return true;
+            }
+
             $agentSealRelations = $app->repo('AgentSealRelation')->findBy(['seal' => 12]);
             $agents = array_map(function($sealRelation) {
                 return $sealRelation->owner;


### PR DESCRIPTION
# Configuração alterada para ativar o módulo EventImporter dinamicamente
Conforme configutação anterior, era necessário adiconar o id do agente em um array para conceder acesso ao módulo de importação de eventos.

De acordo com nova configuração, o agente que tiver controle sobre outro agente que esteja associado com o selo Cultura.CE (12) deverá ter acesso ao módulo.